### PR TITLE
Refactored sign in and log in

### DIFF
--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/LoginSignupActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/LoginSignupActivity.java
@@ -18,8 +18,5 @@ public class LoginSignupActivity extends AppCompatActivity {
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_login_signup);
-
     }
-
-
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/LoginSignupActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/LoginSignupActivity.java
@@ -2,10 +2,9 @@ package com.cmput301f21t26.habittracker;
 
 import androidx.appcompat.app.AppCompatActivity;
 
-import android.content.Intent;
 import android.os.Bundle;
-import android.view.View;
-import android.widget.Button;
+
+import com.cmput301f21t26.habittracker.databinding.ActivityLoginSignupBinding;
 
 /**
  * LoginSignupActivity contains the logic for the page that initially shows up after the
@@ -14,9 +13,13 @@ import android.widget.Button;
  */
 public class LoginSignupActivity extends AppCompatActivity {
 
+    private ActivityLoginSignupBinding binding;
+
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_login_signup);
+
+        binding = ActivityLoginSignupBinding.inflate(getLayoutInflater());
+        setContentView(binding.getRoot());
     }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/MainActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/MainActivity.java
@@ -90,7 +90,9 @@ public class MainActivity extends AppCompatActivity {
                 .build();
 
         // Setting up navController
-        navController = Navigation.findNavController(this, R.id.nav_host_fragment_activity_main);
+        NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment_activity_main);
+        assert navHostFragment != null;
+        navController = navHostFragment.getNavController();
 
         // Clicking on icons navigate to the selected fragments
         navView.setOnItemSelectedListener(new NavigationBarView.OnItemSelectedListener() {

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/MainActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/MainActivity.java
@@ -25,6 +25,7 @@ import androidx.appcompat.widget.Toolbar;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
 import androidx.navigation.NavDirections;
+import androidx.navigation.Navigation;
 import androidx.navigation.fragment.NavHostFragment;
 import androidx.navigation.ui.AppBarConfiguration;
 import androidx.navigation.ui.NavigationUI;
@@ -82,16 +83,14 @@ public class MainActivity extends AppCompatActivity {
         toolbar = findViewById(R.id.toolbar);
         setSupportActionBar(toolbar);
 
-        // Setting up navController
-
         // Passing each menu ID as a set of Ids because each
         // menu should be considered as top level destinations.
         AppBarConfiguration appBarConfiguration = new AppBarConfiguration.Builder(
                 R.id.todays_habits, R.id.navigation_timeline, R.id.navigation_profile)
                 .build();
-        NavHostFragment navHostFragment = (NavHostFragment) getSupportFragmentManager().findFragmentById(R.id.nav_host_fragment_activity_main);
-        assert navHostFragment != null;
-        navController = navHostFragment.getNavController();
+
+        // Setting up navController
+        navController = Navigation.findNavController(this, R.id.nav_host_fragment_activity_main);
 
         // Clicking on icons navigate to the selected fragments
         navView.setOnItemSelectedListener(new NavigationBarView.OnItemSelectedListener() {

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
@@ -2,14 +2,6 @@ package com.cmput301f21t26.habittracker.fragments;
 
 import android.content.Intent;
 import android.os.Bundle;
-
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.Fragment;
-import androidx.navigation.NavController;
-import androidx.navigation.NavDirections;
-import androidx.navigation.Navigation;
-
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -18,12 +10,13 @@ import android.widget.Button;
 import android.widget.EditText;
 import android.widget.Toast;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
 import com.cmput301f21t26.habittracker.MainActivity;
 import com.cmput301f21t26.habittracker.R;
 import com.cmput301f21t26.habittracker.objects.User;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.Task;
-import com.google.firebase.auth.AuthResult;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.firestore.DocumentReference;
 import com.google.firebase.firestore.DocumentSnapshot;

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
@@ -89,7 +89,7 @@ public class LoginFragment extends Fragment {
         usernameET = view.findViewById(R.id.usernameET);
         passwordET = view.findViewById(R.id.passwordET);
         loginConfirmButton = view.findViewById(R.id.loginConfirmButton);
-        loginConfirmButton.setOnClickListener(this);
+        loginConfirmButton.setOnClickListener(loginConfirmOnClickListener);
     }
 
     public void login(String username, String password){
@@ -106,6 +106,7 @@ public class LoginFragment extends Fragment {
                         if (document.exists()){
                             //username exists, get the email and attempt to login
                             User user = document.toObject(User.class);
+                            assert user != null;
                             mAuth.signInWithEmailAndPassword(user.getEmail(), password)
                                 .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
                                     @Override

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
@@ -33,8 +33,7 @@ import com.google.firebase.firestore.FirebaseFirestore;
  * Contains the logic for the Login Fragment
  * Validates inputs, and logs in the user if their username matches their password
  */
-public class LoginFragment extends Fragment implements View.OnClickListener{
-
+public class LoginFragment extends Fragment {
 
     final private String TAG = "loginAuthentication";
     private String username;
@@ -44,8 +43,21 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
     private EditText passwordET;
     private Button loginConfirmButton;
 
-    FirebaseAuth mAuth;
-    FirebaseFirestore mStore;
+    private FirebaseAuth mAuth;
+    private FirebaseFirestore mStore;
+
+    private final View.OnClickListener loginConfirmOnClickListener = view -> {
+        username = usernameET.getText().toString();
+        password = passwordET.getText().toString();
+
+        if (username.isEmpty()) {
+            Toast.makeText(getActivity(), "Must enter a username", Toast.LENGTH_LONG).show();
+        } else if (password.isEmpty()){
+            Toast.makeText(getActivity(), "Must enter a password", Toast.LENGTH_LONG).show();
+        } else {
+            login(username, password);
+        }
+    };
 
     /**
      * Empty constructor
@@ -78,22 +90,6 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
         passwordET = view.findViewById(R.id.passwordET);
         loginConfirmButton = view.findViewById(R.id.loginConfirmButton);
         loginConfirmButton.setOnClickListener(this);
-    }
-
-    @Override
-    public void onClick(View v) {
-        if (v.getId() == R.id.loginConfirmButton){
-            username = usernameET.getText().toString();
-            password = passwordET.getText().toString();
-
-            if (username.isEmpty()) {
-                Toast.makeText(getActivity(), "Must enter a username", Toast.LENGTH_LONG).show();
-            }else if (password.isEmpty()){
-                Toast.makeText(getActivity(), "Must enter a password", Toast.LENGTH_LONG).show();
-            }else{
-                login(username, password);
-            }
-        }
     }
 
     public void login(String username, String password){

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/LoginFragment.java
@@ -43,22 +43,18 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
     private EditText usernameET;
     private EditText passwordET;
     private Button loginConfirmButton;
-    private NavController navController = null;
 
     FirebaseAuth mAuth;
     FirebaseFirestore mStore;
 
     /**
-     * required empty public constructor
+     * Empty constructor
      */
-    public LoginFragment() {
-        // Required empty public constructor
-    }
+    public LoginFragment() { }
 
     /**
      * Initialize the login fragment and get instances
      * @param savedInstanceState
-     *
      */
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -66,8 +62,6 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
 
         mAuth = FirebaseAuth.getInstance();
         mStore = FirebaseFirestore.getInstance();
-
-
     }
 
     @Override
@@ -84,10 +78,7 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
         passwordET = view.findViewById(R.id.passwordET);
         loginConfirmButton = view.findViewById(R.id.loginConfirmButton);
         loginConfirmButton.setOnClickListener(this);
-
-        navController = Navigation.findNavController(view);
     }
-
 
     @Override
     public void onClick(View v) {
@@ -127,6 +118,8 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
                                             Toast.makeText(getActivity(), "Logging in", Toast.LENGTH_LONG).show();
 
                                             Intent intent = new Intent(getActivity(), MainActivity.class);
+                                            // Close existing activity stack and create new root activity
+                                            intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_CLEAR_TASK);
                                             startActivity(intent);
                                         } else {
                                             Toast.makeText(getActivity(), "Wrong password", Toast.LENGTH_LONG).show();
@@ -142,8 +135,5 @@ public class LoginFragment extends Fragment implements View.OnClickListener{
                     }
                 }
             });
-
-
-
     }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/MainLoginSignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/MainLoginSignupFragment.java
@@ -6,6 +6,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.navigation.NavController;
+import androidx.navigation.NavDirections;
 import androidx.navigation.Navigation;
 
 import android.view.LayoutInflater;
@@ -15,9 +16,25 @@ import android.widget.Button;
 
 import com.cmput301f21t26.habittracker.R;
 
-public class MainLoginSignupFragment extends Fragment implements View.OnClickListener {
+public class MainLoginSignupFragment extends Fragment {
 
-    NavController navController = null;
+    private NavController navController;
+
+    private View.OnClickListener loginOnClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            NavDirections direction = MainLoginSignupFragmentDirections.actionMainLoginSignupFragmentToLoginFragment();
+            navController.navigate(direction);
+        }
+    };
+
+    private View.OnClickListener signUpOnClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            NavDirections direction = MainLoginSignupFragmentDirections.actionMainLoginSignupFragmentToSignupFragment();
+            navController.navigate(direction);
+        }
+    };
 
     public MainLoginSignupFragment() {
         // Required empty public constructor
@@ -44,19 +61,7 @@ public class MainLoginSignupFragment extends Fragment implements View.OnClickLis
         navController = Navigation.findNavController(view);
 
         // Set the on click listeners for the buttons
-        view.findViewById(R.id.loginButton).setOnClickListener(this);
-        view.findViewById(R.id.signUpButton).setOnClickListener(this);
-    }
-
-    @Override
-    public void onClick(View view) {
-        if(view != null) {
-            // Get the ID of whatever was clicked, switch to corresponding case
-            if (view.getId() == R.id.loginButton) {
-                navController.navigate(R.id.action_mainLoginSignupFragment_to_loginFragment);
-            } else if (view.getId() == R.id.signUpButton) {
-                navController.navigate(R.id.action_mainLoginSignupFragment_to_signupFragment);
-            }
-        }
+        view.findViewById(R.id.loginButton).setOnClickListener(loginOnClickListener);
+        view.findViewById(R.id.signUpButton).setOnClickListener(signUpOnClickListener);
     }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/MainLoginSignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/MainLoginSignupFragment.java
@@ -12,13 +12,17 @@ import androidx.navigation.Navigation;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 
-import com.cmput301f21t26.habittracker.R;
+import com.cmput301f21t26.habittracker.databinding.FragmentMainLoginSignupBinding;
 
+/**
+ * MainLoginSignupFragment directs the user to either sign up for a new account
+ * or log in to an existing account.
+ */
 public class MainLoginSignupFragment extends Fragment {
 
     private NavController navController;
+    private FragmentMainLoginSignupBinding binding;
 
     private View.OnClickListener loginOnClickListener = new View.OnClickListener() {
         @Override
@@ -40,7 +44,6 @@ public class MainLoginSignupFragment extends Fragment {
         // Required empty public constructor
     }
 
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -48,11 +51,11 @@ public class MainLoginSignupFragment extends Fragment {
     }
 
     @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container,
+    public View onCreateView(@NonNull LayoutInflater inflater, ViewGroup container,
                              Bundle savedInstanceState) {
-        // Inflate the layout for this fragment
-        return inflater.inflate(R.layout.fragment_main_login_signup, container, false);
 
+        binding = FragmentMainLoginSignupBinding.inflate(inflater, container, false);
+        return binding.getRoot();
     }
 
     @Override
@@ -61,7 +64,7 @@ public class MainLoginSignupFragment extends Fragment {
         navController = Navigation.findNavController(view);
 
         // Set the on click listeners for the buttons
-        view.findViewById(R.id.loginButton).setOnClickListener(loginOnClickListener);
-        view.findViewById(R.id.signUpButton).setOnClickListener(signUpOnClickListener);
+        binding.loginButton.setOnClickListener(loginOnClickListener);
+        binding.signUpButton.setOnClickListener(signUpOnClickListener);
     }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/MainLoginSignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/MainLoginSignupFragment.java
@@ -24,7 +24,7 @@ public class MainLoginSignupFragment extends Fragment {
     private NavController navController;
     private FragmentMainLoginSignupBinding binding;
 
-    private View.OnClickListener loginOnClickListener = new View.OnClickListener() {
+    private final View.OnClickListener loginOnClickListener = new View.OnClickListener() {
         @Override
         public void onClick(View view) {
             NavDirections direction = MainLoginSignupFragmentDirections.actionMainLoginSignupFragmentToLoginFragment();
@@ -32,7 +32,7 @@ public class MainLoginSignupFragment extends Fragment {
         }
     };
 
-    private View.OnClickListener signUpOnClickListener = new View.OnClickListener() {
+    private final View.OnClickListener signUpOnClickListener = new View.OnClickListener() {
         @Override
         public void onClick(View view) {
             NavDirections direction = MainLoginSignupFragmentDirections.actionMainLoginSignupFragmentToSignupFragment();
@@ -47,7 +47,6 @@ public class MainLoginSignupFragment extends Fragment {
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-
     }
 
     @Override

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
@@ -20,7 +20,6 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 
 import com.cmput301f21t26.habittracker.R;
-import com.cmput301f21t26.habittracker.objects.User;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.UserProfileChangeRequest;
@@ -253,15 +252,6 @@ public class SignupFragment extends Fragment {
 
         final CollectionReference usersRef = mStore.collection("users");
         mStorageReference = mStorage.getReference(picturePath);
-        // create a hashmap instead of using serializable user so that users don't have
-        // initialized sub-arrays stored, instead we wish to store a collection which
-        // represents the arrays
-        // this is better both because the document size will not grow with the number of habits
-        // and habit events, so fetches will be faster
-        // but also because they're user-defined objects
-        // though firestore supports this its still conceptually cleaner to use subcollections
-        // this does mean that we have to create fake docs for those subcollections
-
 
         mStorageReference
                 .putFile(imageUri)
@@ -297,7 +287,6 @@ public class SignupFragment extends Fragment {
                     });
                 })
                 .addOnFailureListener(e -> Log.d(TAG, "Default profile picture was not stored"));
-
     }
 
     /**

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
@@ -20,10 +20,6 @@ import androidx.navigation.NavController;
 import androidx.navigation.Navigation;
 
 import com.cmput301f21t26.habittracker.R;
-import com.google.android.gms.tasks.OnCompleteListener;
-import com.google.android.gms.tasks.OnFailureListener;
-import com.google.android.gms.tasks.OnSuccessListener;
-import com.google.android.gms.tasks.Task;
 import com.google.firebase.auth.FirebaseAuth;
 import com.google.firebase.auth.FirebaseUser;
 import com.google.firebase.auth.UserProfileChangeRequest;
@@ -33,7 +29,6 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
-import com.google.firebase.storage.UploadTask;
 
 import java.util.Calendar;
 import java.util.HashMap;

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
@@ -185,24 +185,21 @@ public class SignupFragment extends Fragment {
         DocumentReference ref = mStore.collection("users").document(username);
 
         ref.get()
-                .addOnCompleteListener(new OnCompleteListener<DocumentSnapshot>() {
-                    @Override
-                    public void onComplete(@NonNull Task<DocumentSnapshot> task) {
-                        if (task.isSuccessful()) {
-                            DocumentSnapshot document = task.getResult();
-                            assert document != null;
-                            if (document.exists()) {
-                                // Username exists
-                                usernameET.setError("Username already exists");
-                            } else {
-                                // Username does not exist.
-                                createUserFirebaseAuth(firstName, lastName, email, username, password);
-                                creatingUser = true;
-                                Toast.makeText(getActivity(), "Creating user, please wait a moment", Toast.LENGTH_LONG).show();
-                            }
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        DocumentSnapshot document = task.getResult();
+                        assert document != null;
+                        if (document.exists()) {
+                            // Username exists
+                            usernameET.setError("Username already exists");
                         } else {
-                            Log.d(TAG, "Fetching username failed with: ", task.getException());
+                            // Username does not exist.
+                            createUserFirebaseAuth(firstName, lastName, email, username, password);
+                            creatingUser = true;
+                            Toast.makeText(getActivity(), "Creating user, please wait a moment", Toast.LENGTH_LONG).show();
                         }
+                    } else {
+                        Log.d(TAG, "Fetching username failed with: ", task.getException());
                     }
                 });
     }
@@ -224,27 +221,24 @@ public class SignupFragment extends Fragment {
      */
     public void createUserFirebaseAuth(final String firstName, final String lastName, final String email, final String username, final String password) {
         mAuth.createUserWithEmailAndPassword(email, password)
-                .addOnCompleteListener(new OnCompleteListener<AuthResult>() {
-                    @Override
-                    public void onComplete(@NonNull Task<AuthResult> task) {
-                        if (task.isSuccessful()) {
-                            Log.d(TAG, "Creation of User with email successful.");
+                .addOnCompleteListener(task -> {
+                    if (task.isSuccessful()) {
+                        Log.d(TAG, "Creation of User with email successful.");
 
-                            // Set Display Name of user in Firebase Authentication so we can get it in MainActivity
-                            FirebaseUser user = mAuth.getCurrentUser();
-                            if (user != null) {
-                                UserProfileChangeRequest profileUpdate = new UserProfileChangeRequest.Builder()
-                                        .setDisplayName(username).build();
-                                user.updateProfile(profileUpdate);
-                            }
-
-                            // User created in Firebase Authentication, now to add its data into Firestore database
-                            createUserFirebaseFirestore(firstName, lastName, email, username);
-                        } else {
-                            Log.w(TAG, "Creation of User with email failed. " + task.getException().getMessage());
-                            Toast.makeText(getActivity(), task.getException().getMessage(), Toast.LENGTH_LONG).show();
-                            creatingUser = false;
+                        // Set Display Name of user in Firebase Authentication so we can get it in MainActivity
+                        FirebaseUser user = mAuth.getCurrentUser();
+                        if (user != null) {
+                            UserProfileChangeRequest profileUpdate = new UserProfileChangeRequest.Builder()
+                                    .setDisplayName(username).build();
+                            user.updateProfile(profileUpdate);
                         }
+
+                        // User created in Firebase Authentication, now to add its data into Firestore database
+                        createUserFirebaseFirestore(firstName, lastName, email, username);
+                    } else {
+                        Log.w(TAG, "Creation of User with email failed. " + task.getException().getMessage());
+                        Toast.makeText(getActivity(), task.getException().getMessage(), Toast.LENGTH_LONG).show();
+                        creatingUser = false;
                     }
                 });
     }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
@@ -53,7 +53,7 @@ import de.hdodenhof.circleimageview.CircleImageView;
  * Contains the logic for the Signup Fragment.
  * Validates input and attempts to create account with the entered fields.
  */
-public class SignupFragment extends Fragment implements  View.OnClickListener{
+public class SignupFragment extends Fragment {
     final private String TAG = "signupAuthentication";
     private EditText firstNameET;
     private EditText lastNameET;
@@ -74,6 +74,22 @@ public class SignupFragment extends Fragment implements  View.OnClickListener{
     private String profileImageUrl;
 
     private NavController navController = null;
+
+    private final View.OnClickListener signupConfirmOnClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            if (!creatingUser && checkFieldsFilled()) {
+                createUser();
+            }
+        }
+    };
+
+    private final View.OnClickListener setProfileOnClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            mGetContent.launch("image/*");      // Launch file explorer
+        }
+    };
 
     /**
      * Required empty public constructor
@@ -154,42 +170,11 @@ public class SignupFragment extends Fragment implements  View.OnClickListener{
         passwordET = view.findViewById(R.id.passwordET);
         confirmPassET = view.findViewById(R.id.confirmPassET);
         signupConfirmButton = view.findViewById(R.id.signUpConfirmButton);
-        signupConfirmButton.setOnClickListener(this);
+        signupConfirmButton.setOnClickListener(signupConfirmOnClickListener);
         setProfilePic = view.findViewById(R.id.circleImageView);
-        setProfilePic.setOnClickListener(this);
+        setProfilePic.setOnClickListener(setProfileOnClickListener);
 
         navController = Navigation.findNavController(view);
-    }
-
-    /**
-     * Whenever user clicks an element that have OnClickListener, this checks which
-     * element has been clicked and does its corresponding function.
-     *
-     *
-     * @param view
-     *  The current view.
-     */
-    @Override
-    public void onClick(View view) {
-        if(view != null) {
-            // User clicks the signupConfirmButton
-            if (view.getId() == R.id.signUpConfirmButton) {
-                // Make sure there currently isn't a user being created..prevents user from spamming signup button
-                if (!creatingUser) {
-                    // Check if the fields are filled in
-                    if (checkFieldsFilled()) {
-                        createUser();
-                    }
-                } else {
-                    Toast.makeText(getActivity(), "Currently creating user...", Toast.LENGTH_LONG).show();
-                }
-
-            }
-            // User clicks circle image view
-            else if (view.getId() == R.id.circleImageView) {          // If the circle image view is clicked
-                mGetContent.launch("image/*");                    // Launch file explorer
-            }
-        }
     }
 
     /**

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/fragments/SignupFragment.java
@@ -1,7 +1,5 @@
 package com.cmput301f21t26.habittracker.fragments;
 
-import android.app.Activity;
-import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -23,7 +21,6 @@ import android.widget.EditText;
 import android.widget.Toast;
 
 import com.cmput301f21t26.habittracker.R;
-import com.cmput301f21t26.habittracker.objects.User;
 import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
@@ -41,7 +38,6 @@ import com.google.firebase.storage.StorageReference;
 import com.google.firebase.storage.UploadTask;
 
 
-import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
@@ -75,27 +71,6 @@ public class SignupFragment extends Fragment {
 
     private NavController navController = null;
 
-    private final View.OnClickListener signupConfirmOnClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-            if (!creatingUser && checkFieldsFilled()) {
-                createUser();
-            }
-        }
-    };
-
-    private final View.OnClickListener setProfileOnClickListener = new View.OnClickListener() {
-        @Override
-        public void onClick(View view) {
-            mGetContent.launch("image/*");      // Launch file explorer
-        }
-    };
-
-    /**
-     * Required empty public constructor
-     */
-    public SignupFragment() {}
-
     /**
      * Functions essentially like the now deprecated onActivityResult.
      * When User clicks on the circle image view, their default
@@ -118,6 +93,20 @@ public class SignupFragment extends Fragment {
                 }
             });
 
+    private final View.OnClickListener signupConfirmOnClickListener = view -> {
+        if (!creatingUser && checkFieldsFilled()) {
+            createUser();
+        }
+    };
+
+    private final View.OnClickListener setProfileOnClickListener = view -> {
+        mGetContent.launch("image/*");      // Launch file explorer
+    };
+
+    /**
+     * Required empty public constructor
+     */
+    public SignupFragment() {}
 
     /**
      * Initialize the sign up fragment and get instances

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/User.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/User.java
@@ -74,4 +74,19 @@ public class User implements Serializable {
     public void setPictureURL(String pictureURL) {
         this.pictureURL = pictureURL;
     }
+
+    public Date getCreationDate() {
+        return creationDate;
+    }
+
+    public Date getDateLastAccessed() {
+        return dateLastAccessed;
+    }
+
+    /**
+     * Update the date the user accessed to the app to now
+     */
+    public void updateDateLastAccessedToNow() {
+        dateLastAccessed = Calendar.getInstance().getTime();
+    }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/User.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/User.java
@@ -21,6 +21,12 @@ public class User implements Serializable {
     private final Date creationDate;
     private Date dateLastAccessed;
 
+    private final List<String> followings;
+    private final List<String> followers;
+    private final List<Habit> habits;
+    private final List<Habit> todayHabits;
+    private final List<Permission> permissions;
+
     public User(String username, String firstName, String lastName, String email, String pictureURL) {
         this.username = username;
         this.firstName = firstName;
@@ -29,6 +35,12 @@ public class User implements Serializable {
         this.pictureURL = pictureURL;
         this.creationDate = Calendar.getInstance().getTime();
         this.dateLastAccessed = Calendar.getInstance().getTime();
+
+        this.followings = new ArrayList<>();
+        this.followers = new ArrayList<>();
+        this.habits = new ArrayList<>();
+        this.todayHabits = new ArrayList<>();
+        this.permissions = new ArrayList<>();
     }
 
     public User() {
@@ -88,5 +100,41 @@ public class User implements Serializable {
      */
     public void updateDateLastAccessedToNow() {
         dateLastAccessed = Calendar.getInstance().getTime();
+    }
+
+    public List<String> getFollowing() {
+        return followings;
+    }
+
+    public List<String> getFollowers() {
+        return followers;
+    }
+
+    public List<Habit> getHabits() {
+        return habits;
+    }
+
+    public List<Habit> getTodayHabits() {
+        return todayHabits;
+    }
+
+    public List<Permission> getPermissions() {
+        return permissions;
+    }
+
+    public void addFollowing(String uid) {
+        followings.add(uid);
+    }
+
+    public void addFollower(String uid) {
+        followers.add(uid);
+    }
+
+    public void addHabit(Habit habit) {
+        habits.add(habit);
+    }
+
+    public void addTodayHabit(Habit habit) {
+        todayHabits.add(habit);
     }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/User.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/User.java
@@ -21,30 +21,18 @@ public class User implements Serializable {
     private final Date creationDate;
     private Date dateLastAccessed;
 
-    private final List<String> followings;
-    private final List<String> followers;
-    private final List<Habit> habits;
-    private final List<Habit> todayHabits;
-    private final List<Permission> permissions;
-
-    public User(String username, String firstName, String lastName, String email) {
+    public User(String username, String firstName, String lastName, String email, String pictureURL) {
         this.username = username;
         this.firstName = firstName;
         this.lastName = lastName;
         this.email = email;
-        this.pictureURL = null;
+        this.pictureURL = pictureURL;
         this.creationDate = Calendar.getInstance().getTime();
         this.dateLastAccessed = Calendar.getInstance().getTime();
-
-        this.followings = new ArrayList<>();
-        this.followers = new ArrayList<>();
-        this.habits = new ArrayList<>();
-        this.todayHabits = new ArrayList<>();
-        this.permissions = new ArrayList<>();
     }
 
     public User() {
-        this("", "", "", "");
+        this("", "", "", "", "");
     }
 
     public String getUid() {
@@ -77,42 +65,6 @@ public class User implements Serializable {
 
     public void setEmail(String email) {
         this.email = email;
-    }
-
-    public List<String> getFollowing() {
-        return followings;
-    }
-
-    public List<String> getFollowers() {
-        return followers;
-    }
-
-    public List<Habit> getHabits() {
-        return habits;
-    }
-
-    public List<Habit> getTodayHabits() {
-        return todayHabits;
-    }
-
-    public List<Permission> getPermissions() {
-        return permissions;
-    }
-
-    public void addFollowing(String uid) {
-        followings.add(uid);
-    }
-
-    public void addFollower(String uid) {
-        followers.add(uid);
-    }
-
-    public void addHabit(Habit habit) {
-        habits.add(habit);
-    }
-
-    public void addTodayHabit(Habit habit) {
-        todayHabits.add(habit);
     }
 
     public String getPictureURL() {

--- a/code/app/src/main/res/layout/activity_login_signup.xml
+++ b/code/app/src/main/res/layout/activity_login_signup.xml
@@ -7,7 +7,7 @@
     tools:context=".LoginSignupActivity">
 
     <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/loginSignupHostFrag"
+        android:id="@+id/loginSignupHostFragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="0dp"
         android:layout_height="0dp"

--- a/code/app/src/test/java/com/cmput301f21t26/habittracker/UserTest.java
+++ b/code/app/src/test/java/com/cmput301f21t26/habittracker/UserTest.java
@@ -30,7 +30,7 @@ public class UserTest {
         lastName = "Grande";
         email = "NoImNot@Basic.com";
         pictureURL = "google.com/yeeeeeeeeeeeeeeeeeeeeaaaaahh boiiiiiiiiii";
-        userTest = new User(username, firstName, lastName, email);
+        userTest = new User(username, firstName, lastName, email, pictureURL);
     }
 
     /**
@@ -42,11 +42,7 @@ public class UserTest {
         assertEquals(firstName, userTest.getFirstName());
         assertEquals(lastName, userTest.getLastName());
         assertEquals(email, userTest.getEmail());
-        assertTrue(userTest.getFollowers() instanceof ArrayList);
-        assertTrue(userTest.getFollowing() instanceof ArrayList);
-        assertTrue(userTest.getTodayHabits() instanceof ArrayList);
-        assertTrue(userTest.getHabits() instanceof ArrayList);
-        assertTrue(userTest.getPermissions() instanceof ArrayList);
+        assertEquals(pictureURL, userTest.getPictureURL());
     }
 
     /**


### PR DESCRIPTION
- Separated one big OnClickListener
- When signing in, the app does not create the subcollections. It will create them if it needs it
- Instead of adding the user doc into the db then updating its pictureURL field, get the profile URL first then add the user into db.
- When user logs in, clear the existing activity stack
- Replaced appropriate methods to lambdas
- Removed unused imports
- Add back pictureURL to the User constructor