### PR TITLE
UI update; Added remove location button

### DIFF
--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/habitevent/EditHabitEventFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/habitevent/EditHabitEventFragment.java
@@ -70,6 +70,7 @@ public class EditHabitEventFragment extends Fragment {
     private ImageButton habitEventChooseImageBtn;
     private ImageButton habitEventCameraBtn;
     private ImageButton removeImageImageButton;
+    private ImageButton removeLocationImageButton;
 
     private Button chooseLocBtn;
 
@@ -111,6 +112,7 @@ public class EditHabitEventFragment extends Fragment {
         habitEventCameraBtn = (ImageButton) binding.cameraButton;
         removeImageImageButton = binding.removeImageImageButton;
         chooseLocBtn = binding.chooseLocationButton;
+        removeLocationImageButton = binding.removeLocationImageButton;
 
         return binding.getRoot();
     }
@@ -127,6 +129,7 @@ public class EditHabitEventFragment extends Fragment {
         habitEventChooseImageBtn.setOnClickListener(chooseImageOnClickListener);
         removeImageImageButton.setOnClickListener(removeImageOnClickListener);
         chooseLocBtn.setOnClickListener(chooseLocOnClickListener);
+        removeLocationImageButton.setOnClickListener(removeLocationOnClickListener);
         setEditHabitEventFields();
 
 
@@ -150,6 +153,7 @@ public class EditHabitEventFragment extends Fragment {
 
         if (hEvent.getAddress() != null) {
             habitEventLocationTV.setText(hEvent.getAddress());
+            removeLocationImageButton.setVisibility(View.VISIBLE);
         }
 
         if (hEvent.getPhotoUrl() != null) {
@@ -314,6 +318,7 @@ public class EditHabitEventFragment extends Fragment {
                 mGetContent.launch("image/*");  // launch file explorer
             }
         };
+
     /**
      * sets the image chosen from the users library to the image view of the habit event, and updates the
      * PhotoUrl parameter of the respective habit event
@@ -349,6 +354,18 @@ public class EditHabitEventFragment extends Fragment {
         public void onClick(View view) {
             NavDirections direction = EditHabitEventFragmentDirections.actionEditHabitEventFragmentToMapFragment(habit, hEvent);
             navController.navigate(direction);
+        }
+    };
+
+    /**
+     * Removes the location from the habit event when remove image button is clicked
+     */
+    private View.OnClickListener removeLocationOnClickListener = new View.OnClickListener() {
+        @Override
+        public void onClick(View view) {
+            hEvent.setAddress(null);
+            habitEventController.updateHabitEventInDb(hEvent, user -> {});
+            habitEventLocationTV.setText("NONE");
         }
     };
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragment.java
@@ -159,6 +159,9 @@ public class ProfileFragment extends Fragment implements Observer {
                                                 followRequestController.unfollow(otherUser.getUid(), user -> {
                                                     setFollowButton(FollowStatus.NOT_FOLLOWING);
                                                     followStatus = FollowStatus.NOT_FOLLOWING;
+                                                    // reset the tabs and viewpager so then user cannot
+                                                    // view the other user's habits/followers/following after unfollowing
+                                                    setTabsAndViewPager();
                                                     isFollowButtonClicked = false;
                                                 });
                                             }
@@ -213,6 +216,7 @@ public class ProfileFragment extends Fragment implements Observer {
     private void setFollowButton(FollowStatus initStatus) {
         if (initStatus == FollowStatus.NOT_FOLLOWING) {
             followButton.setText("FOLLOW");
+            followButton.setTextColor(ContextCompat.getColor(getContext(), R.color.black));
             followButton.setBackgroundColor(ContextCompat.getColor(getContext(), R.color.green));
         } else if (initStatus == FollowStatus.PENDING) {
             followButton.setBackgroundColor(ContextCompat.getColor(getContext(), R.color.lighter_gray));
@@ -233,7 +237,8 @@ public class ProfileFragment extends Fragment implements Observer {
         FragmentManager fragmentManager = getChildFragmentManager();
         fragmentAdapter = new ProfileFragmentAdapter(fragmentManager, getLifecycle());
         viewPager.setAdapter(fragmentAdapter);
-
+        viewPager.setOffscreenPageLimit(2);     // so we're not creating new pages constantly
+        tabLayout.removeAllTabs();
         tabLayout.addTab(tabLayout.newTab().setText("Habits"));
         tabLayout.addTab(tabLayout.newTab().setText("Followers"));
         tabLayout.addTab(tabLayout.newTab().setText("Following"));

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentFollowersTab.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentFollowersTab.java
@@ -71,6 +71,7 @@ public class ProfileFragmentFollowersTab extends Fragment {
         if (userObject.getUid().equals(UserController.getCurrentUserId())
                 || UserController.getCurrentUser().isFollowing(userObject)) {
 
+            profileFollowersListView.setVisibility(View.VISIBLE);
             // get list of users from user's following list and display it
             otherUserController.getUsersList((ArrayList<String>) userObject.getFollowers(), new UserListCallback() {
                 @Override
@@ -97,7 +98,7 @@ public class ProfileFragmentFollowersTab extends Fragment {
                 }
             });
         } else {
-            profileFollowersListView.setAdapter(null);
+            profileFollowersListView.setVisibility(View.GONE);
         }
     }
 

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentFollowingTab.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentFollowingTab.java
@@ -36,7 +36,6 @@ public class ProfileFragmentFollowingTab extends Fragment {
     private OtherUserController otherUserController;
     private ArrayList<User> usersList;
 
-
     @Override
     public void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -71,6 +70,7 @@ public class ProfileFragmentFollowingTab extends Fragment {
         if (userObject.getUid().equals(UserController.getCurrentUserId())
                 || UserController.getCurrentUser().isFollowing(userObject)) {
 
+            profileFollowingListView.setVisibility(View.VISIBLE);
             // get list of users from user's following list and display it
             otherUserController.getUsersList((ArrayList<String>) userObject.getFollowings(), new UserListCallback() {
                 @Override
@@ -98,7 +98,7 @@ public class ProfileFragmentFollowingTab extends Fragment {
             });
 
         } else {
-            profileFollowingListView.setAdapter(null);
+            profileFollowingListView.setVisibility(View.GONE);
         }
     }
 

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentHabitsTab.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentHabitsTab.java
@@ -72,7 +72,6 @@ public class ProfileFragmentHabitsTab extends Fragment {
         super.onViewCreated(view, savedInstanceState);
 
         navController = Navigation.findNavController(getActivity(), R.id.nav_host_fragment_activity_main);
-
         habitList = (ArrayList<Habit>) userObject.getHabits();
         rvlistener = new HabitAdapter.RecyclerViewClickListener() {
             @Override
@@ -82,10 +81,9 @@ public class ProfileFragmentHabitsTab extends Fragment {
                 navController.navigate(action);
             }
         };
-
+        updateFollowToSeeHabitText();
         updateRecyclerView();
     }
-
 
     /**
      * Updates the recycler view for cases when the current user
@@ -94,8 +92,8 @@ public class ProfileFragmentHabitsTab extends Fragment {
     private void updateRecyclerView() {
         if (userObject.getUid().equals(UserController.getCurrentUserId())
                 || UserController.getCurrentUser().isFollowing(userObject)) {
-            updateFollowToSeeHabitText();
 
+            mRecyclerView.setVisibility(View.VISIBLE);
             // show habits only when the userObject is equal to current user
             // or current user is following userObject
             habitAdapter = new HabitAdapter(habitList, getActivity(), rvlistener);
@@ -118,8 +116,7 @@ public class ProfileFragmentHabitsTab extends Fragment {
             habitAdapter.checkBoxVisibility(View.GONE);
 
         } else {
-            mRecyclerView.setAdapter(null);
-            updateFollowToSeeHabitText();
+            mRecyclerView.setVisibility(View.GONE);
         }
     }
 

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/SearchFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/SearchFragment.java
@@ -66,10 +66,18 @@ public class SearchFragment extends Fragment {
             @Override
             public void onItemClick(AdapterView<?> adapterView, View view, int i, long l) {
                 User otherUser = (User) adapterView.getItemAtPosition(i);
-                otherUserController.getHabitList(otherUser, updatedOtheruser -> {
-                    NavDirections action = MobileNavigationDirections.actionGlobalNavigationProfile(updatedOtheruser);
-                    navController.navigate(action);
+                otherUserController.getUser(otherUser.getUsername(), updatedOtheruser1 -> {
+                    // Re-get other user for cases where current user views the other user's profile from search
+                    // and follows or unfollows that user. Then since other users don't have a snapshot listener
+                    // the current user can go back to the search and reclick the other user to "refresh" the
+                    // other user's info (since we're re-getting the user after every click)
+                    otherUserController.getHabitList(updatedOtheruser1, updatedOtheruser2 -> {
+                        // then we get the habit list of the user and add it to the local User object
+                        NavDirections action = MobileNavigationDirections.actionGlobalNavigationProfile(updatedOtheruser2);
+                        navController.navigate(action);
+                    });
                 });
+
             }
         });
         return view;

--- a/code/app/src/main/res/layout/fragment_edit_habit_event.xml
+++ b/code/app/src/main/res/layout/fragment_edit_habit_event.xml
@@ -120,12 +120,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="@dimen/activity_vertical_margin"
                 android:text="NONE"
+                android:textAlignment="center"
                 android:textColor="@color/blue"
                 android:textSize="16sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.496"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/locationChosenTV" />
+                app:layout_constraintTop_toBottomOf="@+id/locationChosenTV"
+                android:layout_marginHorizontal="24dp"/>
 
             <Button
                 android:id="@+id/chooseLocationButton"
@@ -140,6 +142,23 @@
                 app:layout_constraintHorizontal_bias="0.5"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@+id/habitEventLocationTV" />
+
+            <ImageButton
+                android:id="@+id/removeLocationImageButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/ic_cancel"
+                android:background="@drawable/circle_background"
+                android:scaleX="0.5"
+                android:scaleY="0.5"
+                app:layout_constraintEnd_toStartOf="@id/chooseLocationButton"
+                app:layout_constraintTop_toBottomOf="@id/habitEventLocationTV"
+                app:layout_constraintBottom_toTopOf="@id/divider2"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintHorizontal_bias="1"
+                android:layout_marginStart="@dimen/activity_horizontal_margin"
+                android:visibility="gone"
+                />
 
             <View
                 android:id="@+id/divider2"

--- a/code/app/src/main/res/layout/fragment_map.xml
+++ b/code/app/src/main/res/layout/fragment_map.xml
@@ -15,12 +15,16 @@
 
     <Button
         android:id="@+id/locationConfirmBtn"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="16dp"
-        android:layout_marginBottom="16dp"
-        android:text="CONFIRM"
+        android:layout_width="70dp"
+        android:layout_height="70dp"
+        android:layout_marginEnd="36dp"
+        android:layout_marginBottom="36dp"
+        android:background="@drawable/custom_rounded_square_button"
+        map:elevation="10dp"
+        map:icon="@drawable/ic_checkmark"
+        map:iconSize="38dp"
         map:layout_constraintBottom_toBottomOf="parent"
-        map:layout_constraintEnd_toEndOf="parent" />
+        map:layout_constraintRight_toRightOf="parent"
+        map:layout_constraintVertical_bias="1.0" />
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/layout/fragment_view_habit_event.xml
+++ b/code/app/src/main/res/layout/fragment_view_habit_event.xml
@@ -119,12 +119,14 @@
                 android:layout_height="wrap_content"
                 android:layout_marginVertical="@dimen/activity_vertical_margin"
                 android:text="NONE"
+                android:textAlignment="center"
                 android:textColor="@color/blue"
                 android:textSize="16sp"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintHorizontal_bias="0.496"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/locationChosenTV" />
+                app:layout_constraintTop_toBottomOf="@+id/locationChosenTV"
+                android:layout_marginHorizontal="24dp" />
 
             <View
                 android:id="@+id/divider2"

--- a/code/app/src/main/res/layout/habit_event_content.xml
+++ b/code/app/src/main/res/layout/habit_event_content.xml
@@ -50,7 +50,8 @@
                     android:singleLine="true"
                     android:text="Location"
                     android:textColor="@color/dark_blue"
-                    android:textSize="@dimen/secondary_font_size" />
+                    android:textSize="@dimen/secondary_font_size"
+                    android:layout_marginHorizontal="@dimen/activity_horizontal_margin"/>
 
             </LinearLayout>
 

--- a/code/app/src/main/res/navigation/mobile_navigation.xml
+++ b/code/app/src/main/res/navigation/mobile_navigation.xml
@@ -159,7 +159,7 @@
     <fragment
         android:id="@+id/mapFragment"
         android:name="com.cmput301f21t26.habittracker.ui.habitevent.MapFragment"
-        android:label="MapFragment" >
+        android:label="CHOOSE LOCATION" >
         <action
             android:id="@+id/action_mapFragment_to_editHabitEventFragment"
             app:destination="@id/editHabitEventFragment"


### PR DESCRIPTION
- Before we had to completely get out of the Search fragment inorder to update the other user's profile page, now we just need to go back to the Search fragment and click on the user again to update it. 
- Note that this way is not really efficient, since when we search for a user, we call all matching users and add their User objects to a list, then when clicking a user in search, the new way is to call the database again to get the user with that username. 
- Before it was only using the users that were initially called and added to the users list when clicking on a user in search.

- Fixed bug in profile that I talked about yesterday, the one with the delayed click on users in following/followers (I think its fixed)
- Fixed bug where user sends a follow request to other user, and when other user accepts the follow request while the current user is still viewing the other user's profile, clicking on following or followers tab would show the other user's old followers/following list. 