### PR TITLE
Fix bug #148

### DIFF
--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/HabitEventController.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/HabitEventController.java
@@ -248,7 +248,6 @@ public class HabitEventController {
                 .getDownloadUrl()
                 .addOnSuccessListener(uri ->{
                     // if the image file already exists, download that url and store it in habit event
-                    Log.d("HabitEventImage", "The URL after getting is: " + uri.toString());
                     hEvent.setPhotoUrl(uri.toString());
                     updateHabitEventInDb(hEvent, callback);
                 })
@@ -260,7 +259,6 @@ public class HabitEventController {
                                 .putFile(imageUri)
                                 .addOnSuccessListener(taskSnapshot -> {
                                     storageRef.getDownloadUrl().addOnCompleteListener(task -> {
-                                        Log.d("HabitEventImage", "The URL after storing is: " + task.getResult().toString());
                                         hEvent.setPhotoUrl(task.getResult().toString());
                                         updateHabitEventInDb(hEvent, callback);
                                     });

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/HabitEventController.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/HabitEventController.java
@@ -3,9 +3,11 @@ package com.cmput301f21t26.habittracker.objects;
 import android.net.Uri;
 import android.util.Log;
 
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
 import com.cmput301f21t26.habittracker.interfaces.UserCallback;
+import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.firestore.CollectionReference;
 import com.google.firebase.firestore.DocumentChange;
@@ -227,6 +229,13 @@ public class HabitEventController {
         batch.commit().addOnSuccessListener(unused -> callback.onCallback(user));
     }
 
+    /**
+     * Updates the habit event image url field in the database
+     * @param hEvent The {@link HabitEvent} to be updated in the db
+     * @param picturePath The {@link String} path of the picture in Firebase Storage
+     * @param imageUri The {@link Uri} of the image
+     * @param callback callback function to be called after the update
+     */
     public void updateHabitEventImageInDb(HabitEvent hEvent, String picturePath, Uri imageUri, UserCallback callback) {
 
         User user = userController.getCurrentUser();
@@ -234,16 +243,32 @@ public class HabitEventController {
 
         final StorageReference storageRef = mStorage.getReference(picturePath);
 
-        storageRef
-                .putFile(imageUri)
-                .addOnSuccessListener(taskSnapshot -> {
-                    // If successful, get the download url and store it in pictureURL
-                    storageRef.getDownloadUrl().addOnSuccessListener(url -> {
-                        hEvent.setPhotoUrl(url.toString());
-                        updateHabitEventInDb(hEvent, callback);
-                    });
+        mStorage.getReference()
+                .child(picturePath)
+                .getDownloadUrl()
+                .addOnSuccessListener(uri ->{
+                    // if the image file already exists, download that url and store it in habit event
+                    Log.d("HabitEventImage", "The URL after getting is: " + uri.toString());
+                    hEvent.setPhotoUrl(uri.toString());
+                    updateHabitEventInDb(hEvent, callback);
                 })
-                .addOnFailureListener(e -> Log.d("storeHabitEventImage", "Habit Event Image was not stored"));
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        // If image file doesn't exist, add it to storage and get its url
+                        storageRef
+                                .putFile(imageUri)
+                                .addOnSuccessListener(taskSnapshot -> {
+                                    storageRef.getDownloadUrl().addOnCompleteListener(task -> {
+                                        Log.d("HabitEventImage", "The URL after storing is: " + task.getResult().toString());
+                                        hEvent.setPhotoUrl(task.getResult().toString());
+                                        updateHabitEventInDb(hEvent, callback);
+                                    });
+                                })
+                                .addOnFailureListener(e2 -> Log.d("storeHabitEventImage", "Habit Event Image was not stored"));
+                    }
+                });
+
     }
 
     public void getAllHabitEvents(Habit habit, UserCallback callback) {

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/UserController.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/objects/UserController.java
@@ -257,7 +257,6 @@ public class UserController {
                 .getDownloadUrl()
                 .addOnSuccessListener(uri ->{
                     // if the image file already exists, download that url and store it in user
-                    Log.d("UserControllerPP", "The URL after getting is: " + uri.toString());
                     mStore.collection("users").document(getCurrentUserId())
                             .update("pictureURL", uri.toString())
                             .addOnSuccessListener(unused -> callback.onCallback(user))
@@ -271,7 +270,6 @@ public class UserController {
                                 .putFile(imageUri)
                                 .addOnSuccessListener(taskSnapshot -> {
                                     storageRef.getDownloadUrl().addOnCompleteListener(task -> {
-                                        Log.d("UserControllerPP", "The URL after storing is: " + task.getResult().toString());
                                         mStore.collection("users").document(getCurrentUserId())
                                                 .update("pictureURL", task.getResult().toString())
                                                 .addOnSuccessListener(unused -> callback.onCallback(user))

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/auth/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/auth/SignupFragment.java
@@ -283,7 +283,6 @@ public class SignupFragment extends Fragment {
                 .addOnSuccessListener(uri -> {
                     // if the image file already exists, download that url and store it in user
                     profileImageUrl = uri.toString();
-                    Log.d(TAG, "The profile pic url after getting is : " + profileImageUrl);
                     createUserFirebaseFirestore(profileImageUrl, firstName, lastName, email, username);
 
                 })
@@ -297,7 +296,6 @@ public class SignupFragment extends Fragment {
                                     @Override
                                     public void onComplete(@NonNull Task<Uri> task) {
                                         profileImageUrl = task.getResult().toString();
-                                        Log.d(TAG, "The profile pic url after storing is : " + profileImageUrl);
                                         createUserFirebaseFirestore(profileImageUrl, firstName, lastName, email, username);
                                     }
                                 });

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragment.java
@@ -311,7 +311,7 @@ public class ProfileFragment extends Fragment implements Observer {
             // if for whatever reason the picture path is null
             // make the profile picture the default one
             imageUri = Uri.parse("android.resource://com.cmput301f21t26.habittracker/drawable/default_profile_pic");
-            picturePath = "image/" + imageUri.hashCode() + ".jpeg";
+            picturePath = "image/" + "default_profile_pic" + ".jpeg";
 
             userController.updateProfilePicInDb(picturePath, imageUri, user -> {
                 if (getActivity() != null) {


### PR DESCRIPTION
- Fixed bug #148 
- Problem was that when uploading the same image that already exists in the storage (i.e our default profile pic jpeg), it would replace the already existing image every time, and that would change tokens making the old URLs obsolete, which was causing those load failures in Glide. Now it checks if the file already exists, then it gets it instead of replacing.
- This has been done for both profile picture and habit event image. 