### PR TITLE
Image filenames now generated with UUID instead of using hashCode; Removed Observer from TimelineListAdapter and added missing addObserver to TimelineFragment

### DIFF
--- a/code/app/src/androidTest/java/com/cmput301f21t26/habittracker/MapFragmentTest.java
+++ b/code/app/src/androidTest/java/com/cmput301f21t26/habittracker/MapFragmentTest.java
@@ -39,9 +39,6 @@ public class MapFragmentTest {
         }
 
         //Make sure there is a Habit titled Test and that the box is checked off.
-        Thread.sleep(1000);
-        onView(withId(R.id.navigation_timeline)).perform(click());
-        onView(withId(R.id.navigation_timeline)).check(matches(isDisplayed()));
 
         ViewAction itemViewAction = ActionOnItemView.actionOnItemView(withId(R.id.habitCheckbox), click());
         onView(withId(R.id.todayHabitRV))

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/FollowRequestListAdapter.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/FollowRequestListAdapter.java
@@ -1,4 +1,4 @@
-package com.cmput301f21t26.habittracker.ui.profile;
+package com.cmput301f21t26.habittracker.ui;
 
 import android.content.Context;
 import android.view.LayoutInflater;

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/MainActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/MainActivity.java
@@ -8,6 +8,7 @@ import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.util.Log;
+import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -39,6 +40,8 @@ import com.cmput301f21t26.habittracker.objects.FollowRequest;
 import com.cmput301f21t26.habittracker.objects.OtherUserController;
 import com.cmput301f21t26.habittracker.objects.UserController;
 import com.cmput301f21t26.habittracker.ui.auth.LoginSignupActivity;
+import com.google.android.material.bottomnavigation.BottomNavigationItemView;
+import com.google.android.material.bottomnavigation.BottomNavigationMenuView;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationBarView;
 
@@ -58,6 +61,11 @@ public class MainActivity extends AppCompatActivity implements Observer {
     private Toolbar toolbar;
     private ImageView redCircle;
     private ImageView searchIcon;
+    private BottomNavigationItemView profileItemView;
+    private MenuItem profileItem;
+    private ImageView profilePicIV;
+    private ImageView profilePicOutline;
+    private View profile_badge;
 
     private UserController userController;
     private OtherUserController otherUserController;
@@ -72,6 +80,18 @@ public class MainActivity extends AppCompatActivity implements Observer {
         // find views
         addHabitButton = findViewById(R.id.addHabitButton);
         navView = findViewById(R.id.nav_view);
+
+        // Get profile icon view
+        profileItem = navView.getMenu().findItem(R.id.navigation_profile);
+        BottomNavigationMenuView mbottomNavigationMenuView =
+                (BottomNavigationMenuView) navView.getChildAt(0);
+        View view = mbottomNavigationMenuView.getChildAt(2);
+        profileItemView = (BottomNavigationItemView) view;
+        profile_badge = LayoutInflater.from(this)
+                .inflate(R.layout.profile_pic_icon,
+                        mbottomNavigationMenuView, false);
+        profilePicIV = profile_badge.findViewById(R.id.profilePicIV);
+        profilePicOutline = profile_badge.findViewById(R.id.outline);
 
         // Get our instances
         userController = UserController.getInstance();
@@ -110,16 +130,19 @@ public class MainActivity extends AppCompatActivity implements Observer {
                 int id = item.getItemId();
                 if (id == R.id.todays_habits && !navView.getMenu().findItem(R.id.todays_habits).isChecked()) {
                     action = MobileNavigationDirections.actionGlobalTodaysHabits(null);
+                    profilePicOutline.setVisibility(View.INVISIBLE);
                     navController.navigate(action);
                     return true;
                 }
                 if (id == R.id.navigation_timeline && !navView.getMenu().findItem(R.id.navigation_timeline).isChecked()) {
                     action = MobileNavigationDirections.actionGlobalNavigationTimeline(null);
+                    profilePicOutline.setVisibility(View.INVISIBLE);
                     navController.navigate(action);
                     return true;
                 }
                 if (id == R.id.navigation_profile && !navView.getMenu().findItem(R.id.navigation_profile).isChecked()) {
                     action = MobileNavigationDirections.actionGlobalNavigationProfile(userController.getCurrentUser());
+                    profilePicOutline.setVisibility(View.VISIBLE);
                     navController.navigate(action);
                     return true;
                 }
@@ -134,6 +157,17 @@ public class MainActivity extends AppCompatActivity implements Observer {
                 navController.navigate(action);
             }
         });
+
+    }
+
+    @Override
+    public void onBackPressed() {
+        super.onBackPressed();
+        if (profileItem.isChecked()) {
+            profilePicOutline.setVisibility(View.VISIBLE);
+        } else {
+            profilePicOutline.setVisibility(View.INVISIBLE);
+        }
     }
 
     /**
@@ -367,8 +401,6 @@ public class MainActivity extends AppCompatActivity implements Observer {
      *  The URL that contains an image of the user's profile picture {@link String}
      */
     public void setProfileIconToProfilePic(String URL) {
-
-        MenuItem profileItem = navView.getMenu().findItem(R.id.navigation_profile);
         Glide.with(this)
                 .asBitmap()
                 .load(URL)
@@ -377,8 +409,10 @@ public class MainActivity extends AppCompatActivity implements Observer {
                 .into(new CustomTarget<Bitmap>() {
                     @Override
                     public void onResourceReady(@NonNull Bitmap resource, @Nullable Transition<? super Bitmap> transition) {
-                        navView.setItemIconTintList(null);                  // issue with tinting covering image
-                        profileItem.setIcon(new BitmapDrawable(getResources(), resource));
+                        // if profile pic is loaded properly, then set the OG icon to null and make the profile pic the "icon"
+                        profileItem.setIcon(null);
+                        profilePicIV.setImageBitmap(resource);
+                        profileItemView.addView(profile_badge);
                     }
 
                     @Override

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/MainActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/MainActivity.java
@@ -99,6 +99,7 @@ public class MainActivity extends AppCompatActivity implements Observer {
                 .build();
 
         NavigationUI.setupWithNavController(binding.toolbar, navController, appBarConfiguration);
+        NavigationUI.setupWithNavController(navView, navController);
 
         // Clicking on icons navigate to the selected fragments
         navView.setOnItemSelectedListener(new NavigationBarView.OnItemSelectedListener() {
@@ -107,17 +108,17 @@ public class MainActivity extends AppCompatActivity implements Observer {
                 NavDirections action = null;
 
                 int id = item.getItemId();
-                if (id == R.id.todays_habits) {
+                if (id == R.id.todays_habits && !navView.getMenu().findItem(R.id.todays_habits).isChecked()) {
                     action = MobileNavigationDirections.actionGlobalTodaysHabits(null);
                     navController.navigate(action);
                     return true;
                 }
-                if (id == R.id.navigation_timeline) {
+                if (id == R.id.navigation_timeline && !navView.getMenu().findItem(R.id.navigation_timeline).isChecked()) {
                     action = MobileNavigationDirections.actionGlobalNavigationTimeline(null);
                     navController.navigate(action);
                     return true;
                 }
-                if (id == R.id.navigation_profile) {
+                if (id == R.id.navigation_profile && !navView.getMenu().findItem(R.id.navigation_profile).isChecked()) {
                     action = MobileNavigationDirections.actionGlobalNavigationProfile(userController.getCurrentUser());
                     navController.navigate(action);
                     return true;

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/MainActivity.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/MainActivity.java
@@ -39,10 +39,8 @@ import com.cmput301f21t26.habittracker.objects.FollowRequest;
 import com.cmput301f21t26.habittracker.objects.OtherUserController;
 import com.cmput301f21t26.habittracker.objects.UserController;
 import com.cmput301f21t26.habittracker.ui.auth.LoginSignupActivity;
-import com.cmput301f21t26.habittracker.ui.profile.FollowRequestListAdapter;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.navigation.NavigationBarView;
-import com.google.firebase.auth.FirebaseAuth;
 
 import java.util.ArrayList;
 import java.util.Observable;

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/auth/SignupFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/auth/SignupFragment.java
@@ -45,6 +45,7 @@ import java.util.Calendar;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 import de.hdodenhof.circleimageview.CircleImageView;
 
@@ -187,7 +188,7 @@ public class SignupFragment extends Fragment {
                 public void onActivityResult(Uri uri) {
                     // Make sure uri not null; uri null can occur when we click to go to file explorer and press the back button without choosing an image
                     if (uri != null) {
-                        picturePath = "image/" + uri.hashCode() + ".jpeg";
+                        picturePath = "image/" + UUID.randomUUID().toString() + ".jpeg";
                         imageUri = uri;
                         setProfilePic.setImageURI(uri);
                     }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/habitevent/EditHabitEventFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/habitevent/EditHabitEventFragment.java
@@ -46,6 +46,7 @@ import com.google.android.material.textfield.TextInputEditText;
 import java.io.ByteArrayOutputStream;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
+import java.util.UUID;
 
 public class EditHabitEventFragment extends Fragment {
 
@@ -286,7 +287,7 @@ public class EditHabitEventFragment extends Fragment {
                     removeImageImageButton.setVisibility(View.VISIBLE);
 
                     uri = getImageUri(getContext(), captureImage);
-                    picturePath = "eventPictures/" + uri.hashCode() + ".jpeg";
+                    picturePath = "eventPictures/" + UUID.randomUUID().toString() + ".jpeg";
                     habitEventController.updateHabitEventImageInDb(hEvent, picturePath, uri, user -> {
 
                     });
@@ -331,7 +332,7 @@ public class EditHabitEventFragment extends Fragment {
                             habitEventImage.setImageURI(uri);
                             removeImageImageButton.setVisibility(View.VISIBLE);
 
-                            picturePath = "eventPictures/" + uri.hashCode() + ".jpeg";
+                            picturePath = "eventPictures/" + UUID.randomUUID().toString() + ".jpeg";
                             habitEventController.updateHabitEventImageInDb(hEvent, picturePath, uri, user -> { });
                         }
                     }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragment.java
@@ -37,6 +37,7 @@ import com.google.android.material.tabs.TabLayout;
 
 import java.util.Observable;
 import java.util.Observer;
+import java.util.UUID;
 
 import de.hdodenhof.circleimageview.CircleImageView;
 
@@ -336,8 +337,8 @@ public class ProfileFragment extends Fragment implements Observer {
                     // Make sure uri not null; uri null can occur when we click to go to file explorer and press the back button without choosing an image
                     if (uri != null) {
                         newImageUri = uri;
-                        if (newImageUri != imageUri && newImageUri != null) {
-                            picturePath = "image/" + newImageUri.hashCode() + ".jpeg";
+                        if (newImageUri != imageUri) {
+                            picturePath = "image/" + UUID.randomUUID().toString() + ".jpeg";
                             profilePic.setImageURI(newImageUri);
                             imageUri = newImageUri;
 

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentFollowersTab.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/profile/ProfileFragmentFollowersTab.java
@@ -60,7 +60,7 @@ public class ProfileFragmentFollowersTab extends Fragment {
 
         navController = Navigation.findNavController(getActivity(), R.id.nav_host_fragment_activity_main);
 
-        updateFollowToSeeFollowingText();
+        updateFollowToSeeFollowersText();
         updateListView();
         return view;
     }
@@ -110,7 +110,7 @@ public class ProfileFragmentFollowersTab extends Fragment {
      * Reveals the text "FOLLOW THIS USER TO SEE THEIR FOLLOWERS"
      * if user is not following, shown otherwise.
      */
-    private void updateFollowToSeeFollowingText() {
+    private void updateFollowToSeeFollowersText() {
         if (!userObject.getUid().equals(userController.getCurrentUserId())) {
             if (userController.getCurrentUser().isFollowing(userObject)) {
                 lockFollowersImageView.setVisibility(View.GONE);

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/timeline/TimelineFragment.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/timeline/TimelineFragment.java
@@ -45,17 +45,15 @@ public class TimelineFragment extends Fragment implements Observer {
                              ViewGroup container, Bundle savedInstanceState) {
 
         binding = FragmentTimelineBinding.inflate(inflater, container, false);
-
+        timelineListView = binding.timelineListView;
         userController = UserController.getInstance();
-
+        userController.addObserverToCurrentUser(this);
         return binding.getRoot();
     }
 
     @Override
     public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
-
-
 
         navController = Navigation.findNavController(getActivity(), R.id.nav_host_fragment_activity_main);
 
@@ -70,8 +68,6 @@ public class TimelineFragment extends Fragment implements Observer {
         if (allHabitEventsList.isEmpty()) {
             binding.noHabitEventsTV.setVisibility(View.VISIBLE);
         }
-
-        timelineListView = binding.timelineListView;
 
         if (getActivity() != null) {
             // Sort habitEventsList in chronological order
@@ -116,5 +112,7 @@ public class TimelineFragment extends Fragment implements Observer {
         for (Habit habit : habitsList) {
             allHabitEventsList.addAll(habit.getHabitEvents());
         }
+
+        timelineListAdapter.notifyDataSetChanged();
     }
 }

--- a/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/timeline/TimelineListAdapter.java
+++ b/code/app/src/main/java/com/cmput301f21t26/habittracker/ui/timeline/TimelineListAdapter.java
@@ -27,7 +27,7 @@ import java.util.Observer;
  * adapt the size of the item depending on the
  * available info.
  */
-public class TimelineListAdapter extends BaseAdapter implements Observer {
+public class TimelineListAdapter extends BaseAdapter {
     private String TAG = "TimelineListAdapter";
     private ArrayList<HabitEvent> hEventsList;
     private Context mContext;
@@ -43,7 +43,6 @@ public class TimelineListAdapter extends BaseAdapter implements Observer {
         }
         userController = UserController.getInstance();
 
-        userController.addObserverToCurrentUser(this);
     }
 
     @Override
@@ -130,10 +129,5 @@ public class TimelineListAdapter extends BaseAdapter implements Observer {
         }
 
         return convertView;
-    }
-
-    @Override
-    public void update(Observable observable, Object o) {
-        notifyDataSetChanged();
     }
 }

--- a/code/app/src/main/res/layout/fragment_profile.xml
+++ b/code/app/src/main/res/layout/fragment_profile.xml
@@ -1,15 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true"
     tools:context=".ui.profile.ProfileFragment">
-
-    <androidx.constraintlayout.widget.ConstraintLayout
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
 
         <de.hdodenhof.circleimageview.CircleImageView
             android:id="@+id/profilePicImageView"
@@ -207,5 +203,4 @@
             app:layout_constraintTop_toBottomOf="@+id/followingBackground" />
 
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
-</ScrollView>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/code/app/src/main/res/layout/profile_pic_icon.xml
+++ b/code/app/src/main/res/layout/profile_pic_icon.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_gravity="center">
+
+    <FrameLayout
+        android:layout_width="@dimen/menu_item_ripple_size"
+        android:layout_height="@dimen/menu_item_ripple_size"
+        android:layout_gravity="center"
+        android:background="?attr/selectableItemBackgroundBorderless">
+
+        <ImageView
+            android:id="@+id/outline"
+            android:layout_width="16dp"
+            android:layout_height="wrap_content"
+            android:scaleY="1.75"
+            android:scaleX="1.75"
+            android:layout_gravity="center"
+            android:background="@drawable/red_circle"
+            android:backgroundTint="@color/green"
+            android:visibility="invisible"
+            />
+
+        <ImageView
+            android:id="@+id/profilePicIV"
+            android:layout_width="@dimen/menu_item_icon_size"
+            android:layout_height="@dimen/menu_item_icon_size"
+            android:layout_gravity="center"
+            android:scaleX="0.7"
+            android:scaleY="0.7"
+            android:src="@drawable/default_profile_pic"
+            android:visibility="visible"/>
+
+
+
+    </FrameLayout>
+
+
+
+</FrameLayout>

--- a/code/app/src/main/res/menu/bottom_nav_menu.xml
+++ b/code/app/src/main/res/menu/bottom_nav_menu.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<menu xmlns:android="http://schemas.android.com/apk/res/android">
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
         android:id="@+id/todays_habits"
@@ -13,7 +14,7 @@
 
     <item
         android:id="@+id/navigation_profile"
-        android:icon="@drawable/ic_person"
-        android:title="Profile" />
+        android:title="Profile"
+        android:icon="@drawable/ic_person"/>
 
 </menu>


### PR DESCRIPTION
- Image file names are generated randomly with UUID now, as hashCodes don't guarantee a unique code
- Because of that, there is no longer a need to check if the file exists in the storage before storing, so that is removed from the updateProfilePicInDb in UserController and storeProfilePic in AuthController
- Removed Observer from TimelineListAdapter (wasn't doing anything afaik, cuz we already have an Observer in TimelineFragment)
- Added missing userController.addObserverToCurrentUser(this) in TimelineFragment. This was why habit event images were not updated correctly after choosing an image in EditHabitEventFragment and clicking the confirm button to go back to the Timeline.

- Fixed incorrect selected item in bottom navigation when pressing back button
- Profile Icon in bottom navigation does not look like doodoo now, and highlights when clicked